### PR TITLE
Makes the bots use trek chems to treat patients

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/medbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/medbot.dm
@@ -40,6 +40,15 @@
 	var/declare_cooldown = 0 //Prevents spam of critical patient alerts.
 	var/stationary_mode = 0 //If enabled, the Medibot will not move automatically.
 	//Setting which reagents to use to treat what by default. By id.
+    var/treatment_brute_avoid = /datum/reagent/medicine/tricordrazine
+    var/treatment_brute = /datum/reagent/medicine/bicaridine
+    var/treatment_fire_avoid = /datum/reagent/medicine/tricordrazine
+    var/treatment_fire = /datum/reagent/medicine/kelotane
+    var/treatment_tox_avoid = /datum/reagent/medicine/tricordrazine
+    var/treatment_tox = /datum/reagent/medicine/charcoal
+    var/treatment_virus_avoid = null
+    var/treatment_virus = /datum/reagent/medicine/spaceacillin
+    var/treat_virus = 1 //If on, the bot will attempt to treat viral infections, curing them if possible.
 	var/shut_up = 0 //self explanatory :)
 	var/datum/techweb/linked_techweb
 


### PR DESCRIPTION
Makes the bots treat patients with the trek chems up to a certain threshold, it might work, maybe.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
makes the bots use trek chems when treating patients 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
the game is so unbalanced bro we should just delete the server bro, yeah fuck off, its so unbalanced we should just delete it, that will balance it. 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
Adds: Trek Chems in medbot use. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
